### PR TITLE
Don't throw Exception (return null) if there are no stories in the feed 

### DIFF
--- a/InstaSharper/Converters/InstaStoryConverter.cs
+++ b/InstaSharper/Converters/InstaStoryConverter.cs
@@ -11,7 +11,7 @@ namespace InstaSharper.Converters
 
         public InstaStory Convert()
         {
-            if (SourceObject == null) throw new ArgumentNullException($"Source object");
+            if (SourceObject == null) return null;
             var story = new InstaStory
             {
                 CanReply = SourceObject.CanReply,


### PR DESCRIPTION
Issue: receiving exceptions on ALL feeds without stories. Apparently, we don't need exception in this case.
Fix: return null instead of throw.

works fine now for location, user and hashtag feeds without exceptions