### PR TITLE
if logout failed, IsAuthenticated will not change.

### DIFF
--- a/InstaSharper/API/InstaApi.cs
+++ b/InstaSharper/API/InstaApi.cs
@@ -1002,9 +1002,9 @@ namespace InstaSharper.API
                 var json = await response.Content.ReadAsStringAsync();
                 if (response.StatusCode != HttpStatusCode.OK) return Result.UnExpectedResponse<bool>(response, json);
                 var logoutInfo = JsonConvert.DeserializeObject<BaseStatusResponse>(json);
-                var loggedOut = logoutInfo.Status == "ok";
-                IsUserAuthenticated = !loggedOut;
-                return Result.Success(loggedOut);
+                if (logoutInfo.Status == "ok")
+                    IsUserAuthenticated = false;
+                return Result.Success(!IsUserAuthenticated);
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
for best practice, only set IsAuthenticated when logout success.
when it's fail, don't make change to the property .

unexpected behavior :
if we accidentally call logout twice, the api state will be IsAuthenticated = true.