### PR TITLE
Fixed bug with time in recent activities

### DIFF
--- a/InstaSharper/Classes/Models/InstaRecentActivityFeed.cs
+++ b/InstaSharper/Classes/Models/InstaRecentActivityFeed.cs
@@ -5,7 +5,11 @@ namespace InstaSharper.Classes.Models
 {
     public class InstaRecentActivityFeed
     {
+        public string MediaId { get; set; }
+
         public long ProfileId { get; set; }
+
+        public string ProfileName { get; set; }
 
         public string ProfileImage { get; set; }
 

--- a/InstaSharper/Classes/ResponseWrappers/InstaRecentActivityStoryItemMediaResponse.cs
+++ b/InstaSharper/Classes/ResponseWrappers/InstaRecentActivityStoryItemMediaResponse.cs
@@ -1,0 +1,9 @@
+﻿using Newtonsoft.Json;
+
+namespace InstaSharper.Classes.ResponseWrappers
+{
+    public class InstaRecentActivityStoryItemMediaResponse
+    {
+        [JsonProperty("id")] public string MediaId { get; set; }
+    }
+}

--- a/InstaSharper/Classes/ResponseWrappers/InstaRecentActivityStoryItemResponse.cs
+++ b/InstaSharper/Classes/ResponseWrappers/InstaRecentActivityStoryItemResponse.cs
@@ -7,6 +7,8 @@ namespace InstaSharper.Classes.ResponseWrappers
     {
         [JsonProperty("profile_id")] public long ProfileId { get; set; }
 
+        [JsonProperty("profile_name")] public string ProfileName { get; set; }
+
         [JsonProperty("profile_image")] public string ProfileImage { get; set; }
 
         [JsonProperty("timestamp")] public string TimeStamp { get; set; }
@@ -16,5 +18,7 @@ namespace InstaSharper.Classes.ResponseWrappers
         [JsonProperty("text")] public string Text { get; set; }
 
         [JsonProperty("links")] public List<InstaLinkResponse> Links { get; set; }
+
+        [JsonProperty("media")] public List<InstaRecentActivityStoryItemMediaResponse> Medias { get; set; }
     }
 }

--- a/InstaSharper/Converters/InstaRecentActivityConverter.cs
+++ b/InstaSharper/Converters/InstaRecentActivityConverter.cs
@@ -18,7 +18,7 @@ namespace InstaSharper.Converters
                 ProfileId = SourceObject.Args.ProfileId,
                 ProfileImage = SourceObject.Args.ProfileImage,
                 Text = SourceObject.Args.Text,
-                TimeStamp = DateTimeHelper.UnixTimestampToDateTime(SourceObject.Args.TimeStamp)
+                TimeStamp = DateTimeHelper.UnixTimestampToDateTime(SourceObject.Args.TimeStamp.Split('.')[0])
             };
             if (SourceObject.Args.Links != null)
                 foreach (var instaLinkResponse in SourceObject.Args.Links)

--- a/InstaSharper/Converters/InstaRecentActivityConverter.cs
+++ b/InstaSharper/Converters/InstaRecentActivityConverter.cs
@@ -1,4 +1,5 @@
-﻿using InstaSharper.Classes.Models;
+﻿using System.Linq;
+using InstaSharper.Classes.Models;
 using InstaSharper.Classes.ResponseWrappers;
 using InstaSharper.Helpers;
 
@@ -16,8 +17,10 @@ namespace InstaSharper.Converters
                 Pk = SourceObject.Pk,
                 Type = SourceObject.Type,
                 ProfileId = SourceObject.Args.ProfileId,
+                ProfileName = SourceObject.Args.ProfileName,
                 ProfileImage = SourceObject.Args.ProfileImage,
                 Text = SourceObject.Args.Text,
+                MediaId = SourceObject.Args.Medias?.FirstOrDefault()?.MediaId,
                 TimeStamp = DateTimeHelper.UnixTimestampToDateTime(SourceObject.Args.TimeStamp.Split('.')[0])
             };
             if (SourceObject.Args.Links != null)


### PR DESCRIPTION
Instagram Recent Activities endpoint return response with timestamp fields and to these fields Instagram added some hash after a dot. For example `1548842217.26095`
In my PR I removed the hash.

Call `instaApi.GetRecentActivityAsync ` throw Exception, now.