### PR TITLE
Fix: carousel uploads but returns an empty instance of InstaMediaItemResponse

### DIFF
--- a/InstaSharper/API/Processors/MediaProcessor.cs
+++ b/InstaSharper/API/Processors/MediaProcessor.cs
@@ -502,8 +502,8 @@ namespace InstaSharper.API.Processors
                 var json = await response.Content.ReadAsStringAsync();
                 if (!response.IsSuccessStatusCode)
                     return Result.UnExpectedResponse<InstaMedia>(response, json);
-                var mediaResponse = JsonConvert.DeserializeObject<InstaMediaItemResponse>(json);
-                var converter = ConvertersFabric.Instance.GetSingleMediaConverter(mediaResponse);
+                var mediaResponse = JsonConvert.DeserializeObject<InstaMediaAlbumResponse>(json);
+                var converter = ConvertersFabric.Instance.GetSingleMediaConverter(mediaResponse?.Media);
                 return Result.Success(converter.Convert());
             }
             catch (Exception exception)

--- a/InstaSharper/Classes/ResponseWrappers/InstaMediaAlbumResponse.cs
+++ b/InstaSharper/Classes/ResponseWrappers/InstaMediaAlbumResponse.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace InstaSharper.Classes.ResponseWrappers
+{
+    public class InstaMediaAlbumResponse
+    {
+        [JsonProperty("media")] public InstaMediaItemResponse Media { get; set; }
+
+        [JsonProperty("client_sidecar_id")] public string ClientSidecarId { get; set; }
+
+        [JsonProperty("status")] public string Status { get; set; }
+    }
+}


### PR DESCRIPTION
Fix a bug when `UploadPhotosAlbum` method returns an empty instance of `InstaMediaItemResponse`. 

When the album was uploaded instagram returns json like 
`{ "client_sidecar_id":"...", "media":{...}, "status":"..." }` 
so `JsonConvert` could not deserialize it into `InstaMediaItemResponse`