### PR TITLE
Fixing wrong access modifier

### DIFF
--- a/InstaSharper/API/Builder/InstaApiBuilder.cs
+++ b/InstaSharper/API/Builder/InstaApiBuilder.cs
@@ -17,7 +17,7 @@ namespace InstaSharper.API.Builder
         private ApiRequestMessage _requestMessage;
         private UserSessionData _user;
 
-        private InstaApiBuilder()
+        public InstaApiBuilder()
         { }
 
         /// <summary>


### PR DESCRIPTION
Cannot use api if constructor is private >_>